### PR TITLE
Added ability to rename a subtopic on MQTT

### DIFF
--- a/LYWSD03MMC.py
+++ b/LYWSD03MMC.py
@@ -65,8 +65,13 @@ def myMQTTPublish(topic,jsonMessage):
 	if len(subtopics) > 0:
 		messageDict = json.loads(jsonMessage)
 		for subtopic in subtopics:
-			print("Topic:",subtopic)
-			MQTTClient.publish(topic + "/" + subtopic,messageDict[subtopic],0)
+			if "=" in subtopic:
+				subtopic = subtopic.split("=")
+				print("Topic:",subtopic[0], "(", subtopic[1], ")")
+				MQTTClient.publish(topic + "/" + subtopic[0],messageDict[subtopic[1]],0)
+			else:
+				print("Topic:",subtopic)
+				MQTTClient.publish(topic + "/" + subtopic,messageDict[subtopic],0)
 	if not mqttJSONDisabled:
 		MQTTClient.publish(topic,jsonMessage,1)
 

--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ basement/livingroom/humidity
 ``` 
 When using subtopics options you should configure a topic for each sensor otherwise values would get mixed under topic `ATCThermometer/temperature`, of course.
 
+Subtopics can be given custom names using `custom_value_name=value_name` when defining a subtopic. This can be used to have multiple receivers pointing to the same topics, with different RSSI subtopics using the option `subtopics=temperature,voltage,humidity,rx1_rssi=rssi` on one device and `subtopics=temperature,voltage,humidity,rx2_rssi=rssi` on another.
 
 Still there is also the JSON output at topic `ATCThermometer` respectively `basement/livingroom` 
 To disable JSON output in this case, append nojson to suptopics, so in this case `subtopics=temperature,voltage,humidity,nojson`

--- a/mqtt.conf
+++ b/mqtt.conf
@@ -35,5 +35,7 @@ clientid=
 receivername=
 ;enable subtopics like temperature and humidity, combine with comma without spaces so "temperature,humidity"
 ;to disable JSON output, add "nojson"
+;to rename a subtopic, use your new name followed by = and then the original name
 ;subtopics=nojson,temperature,humidity will send temperature and humidity
+;subtopics=nojson,temp=temperature,rh=humidity will send temperature and humidity shortened to temp and rh
 subtopics=


### PR DESCRIPTION
I wanted to be able to rename a subtopic to be able to support different receivers publishing different rssi values to the same topic each with their own subtopic. Made a simple change that allows you to rename a subtopic using an equals sign