### PR TITLE
Unbound local error for repeated packets in encrypted mode

### DIFF
--- a/LYWSD03MMC.py
+++ b/LYWSD03MMC.py
@@ -663,6 +663,8 @@ elif args.passive:
 							else:
 								print("Warning: No key provided for sensor:", mac,"\n")
 								return
+						else
+							return #repeated packet
 					else: #no fitting packet
 						return
 


### PR DESCRIPTION
Hello 😄 It looks like in case of using encrypted custom format and having a measurement interval set as 4x advertising interval there is a missing else statement which causes this exception to occur three times after first measurement is sent:

```
Exception when calling handler with a BLE advertising event: UnboundLocalError("local variable 'batteryPercent' referenced before assignment")
Traceback (most recent call last):
  File "/home/pi/src/MiTemperature2/bluetooth_utils.py", line 372, in parse_le_advertising_events
    handler(mac_addr_str, adv_type, data, rssi)
  File "LYWSD03MMC.py", line 710, in le_advertise_packet_handler
    decode_data_atc(mac, adv_type, data_str, rssi, measurement)
  File "LYWSD03MMC.py", line 672, in decode_data_atc
    measurement.battery = batteryPercent
UnboundLocalError: local variable 'batteryPercent' referenced before assignment
```