### PR TITLE
More convenient dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,25 +1,17 @@
-# Start from a Python3.7 base image I published
+FROM python:3.9
 
-FROM xavierrrr/xrrzero:stretchpython3.7 
+RUN apt-get update
 
-# http://bugs.python.org/issue19846
-# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-ENV LANG C.UTF-8
+RUN apt-get -y install python3-pip libglib2.0-dev libbluetooth-dev bluetooth
 
-RUN sudo apt-get update
+RUN pip3 install bluepy
+RUN pip3 install requests
+# pybluez wont compile with the newer version
+RUN pip3 install --upgrade setuptools==57.5.0
+RUN pip3 install pybluez
+RUN pip3 install pycryptodomex
+RUN pip3 install paho-mqtt
 
-RUN sudo apt-get -y --no-install-recommends install python-pip libglib2.0-dev
+COPY . /app
 
-RUN /usr/local/bin/pip3.7 install bluepy
-RUN /usr/local/bin/pip3.7 install requests
-
-COPY LYWSD03MMC.py LYWSD03MMC.py 
-COPY sendtovera.py sendtovera.py 
-
-ENTRYPOINT service dbus start
-
-#Change to the following line to match your needs
-
-ENTRYPOINT while true; do /usr/local/bin/python3.7m LYWSD03MMC.py -d A4:C1:38:7F:E6:DC -r -b 100 --skipidentical 50 -deb --callback sendtovera.py; sleep 2; done
-
-# start the created image with sudo docker run --net=host -t your_image_name /bin/bash
+ENTRYPOINT ["python3", "/app/LYWSD03MMC.py"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,33 +1,32 @@
+# Docker image
 
-# Raspberry pi zero docker image
-
-It might be difficult and/or tedious to install all prereqs on a pi zero.
-(and Python 3.7 is long to build from sources compiling on the pi zero).
-
-I've been willing to try docker on the pi zero as a way to "easyly" move applications/functions from one pi to another without needing to care (as much as possible) of all the prerequisits and potentially conflicting other apps.
+It's pretty straightforward to run the script using the dockerfile provided here.
 
 #Usage:
 
-## Building the docker image from base image (base image based on stretch + python 3)
+## Building the docker image
 
-I published the base image as xavierrrr/xrrzero:stretchpython3.7 in dockerhub. 
+Run the following docker build command from the project root directory
 
-Run the following docker build command from project root directory
+Docker needs to be running as root due to the dependencies of the project so if you use rootless docker, you may need to use `sudo` for each docker command.
 
 ```
-docker build -t mitemperature2localimage -f docker/Dockerfile .
+docker build -t mitemperature2 -f docker/Dockerfile .
 ```
-
-**Update the Dockerfile with you sensor mac adress**
-
-**Update the LYWSD03MMC.py command line for your use. The default file will invoke a simple callback python programs that is updating a vera verde box with sensor data.**
 
 ## Starting the docker image
+
 ```
-sudo docker run --net=host -d -i -t mitemperature2localimage
+docker run --net=host --privileged -it mitemperature2 <parameters>
 ```
 
-# Pi Zero Docker installation on a frech stretch/buster installation
+Example:
+
+```
+docker run --net=host --privileged -it mitemperature2 -a --devicelistfile /app/sensors.ini --mqttconfigfile /app/mqtt.conf
+```
+
+# Raspberry Pi Docker installation
 
 **I'm putting this here for quick reference**
 


### PR DESCRIPTION
With this patch the dockerfile doesn't need to be updated according to the user's requirements. The script parameters can be provided to the command without requiring to update the dockerfile

dbus is also not necessary when `--privileged` is provided. `--net=host` is also required to be able to use bluetooth address family in sockets.

It doesn't work with Python 3.10 currently because `pybluez` has incompatible API.