### PR TITLE
use slim docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,16 +1,11 @@
-FROM python:3.9
+FROM python:3.9-slim
 
-RUN apt-get update
-
-RUN apt-get -y install python3-pip libglib2.0-dev libbluetooth-dev bluetooth
-
-RUN pip3 install bluepy
-RUN pip3 install requests
-# pybluez wont compile with the newer version
-RUN pip3 install --upgrade setuptools==57.5.0
-RUN pip3 install pybluez
-RUN pip3 install pycryptodomex
-RUN pip3 install paho-mqtt
+# pybluez wont compile with the newer version of setuptools so use fixed version
+RUN apt update && \
+ apt -y upgrade && \
+ apt -y install python3-pip libglib2.0-dev libbluetooth-dev bluetooth && \
+ pip3 install --upgrade setuptools==57.5.0 && \
+ pip3 install bluepy requests pybluez pycryptodomex paho-mqtt
 
 COPY . /app
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -26,6 +26,12 @@ Example:
 docker run --net=host --privileged -it mitemperature2 -a --devicelistfile /app/sensors.ini --mqttconfigfile /app/mqtt.conf
 ```
 
+You can use this to run with sensors.ini and mqtt.conf on the host machine rather than having to use the versions in the docker repository
+
+```
+docker run --net=host --privileged -it -v $(pwd)/sensors.ini:/app/sensors.ini -v $(pwd)/mqtt.conf:/app/mqtt.conf  mitemperature2 -a --devicelistfile /app/sensors.ini --mqttconfigfile /app/mqtt.conf
+```
+
 # Raspberry Pi Docker installation
 
 **I'm putting this here for quick reference**


### PR DESCRIPTION
This changes the Dockerfile to use a smaller version of python and to do the installs in one layer which results in a smaller image to download from a docker registry.   

I have also added some instructions to allow you to run the docker image but have sensors.ini and mqtt.conf on the host machine rather than relying on the ones in the docker image