### PR TITLE
Added libglib2.0-dev information in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,13 @@ For example Raspbian Stretch has only Python 3.5.3. If you like to upgrade your 
 
 If you like installing/compiling Python3.7 please take a look at this tutorial https://gist.github.com/SeppPenner/6a5a30ebc8f79936fa136c524417761d However it took about 5 hours to compile/run the regressiontests on a Raspberry Pi3B. I use this compiled version directly without install. If you do, too, you have to change the first line in the script, pointing to your compiled Python version. For bluepy you can copy the bluepy-folder from home/pi/.local/lib/python3.7/site-packages/bluepy to <yourPath>Python-3.7.4/Lib and do a chmod +x bluepy-helper in <yourPath>Python-3.7.4/Lib/bluepy.
 
-Prequisites: python3 bluez python3-pip libbluetooth-dev bluepy requests
+Prequisites: python3 bluez python3-pip libbluetooth-dev libglib2.0-dev (Bookworm) bluepy requests
 install via
 
 `sudo apt install python3 bluez python3-pip libbluetooth-dev`
+
+Debian/Raspbian 12 Bookworm additionally (necessary to install bluepy):  
+`sudo apt install libglib2.0-dev`
 
 `pip3 install bluepy requests`
 


### PR DESCRIPTION
Updating README.md to include missing `libglib2.0-dev` system dependency in Debian/Raspbian 12 Bookworm to fix #122 

Based on [Installation](https://github.com/IanHarvey/bluepy#installation) section of [bluepy repository](https://github.com/IanHarvey/bluepy)